### PR TITLE
Hotfix: Corregir centrado del nombre del archivo en modal

### DIFF
--- a/frontend/src/components/account/showShareInformationsModal.tsx
+++ b/frontend/src/components/account/showShareInformationsModal.tsx
@@ -133,7 +133,7 @@ const showShareInformationsModal = (
                     </Box>
                   )}
                   <Tooltip label={share.files[0].name} position="bottom" multiline maw={400}>
-                    <Text size="sm" weight={500} align="center" sx={{ cursor: 'help' }}>
+                    <Text size="sm" weight={500} align="center" sx={{ cursor: 'help', textAlign: 'center', width: '100%' }}>
                       {truncateFileName(share.files[0].name, 45)}
                     </Text>
                   </Tooltip>


### PR DESCRIPTION
## Summary
- Corregido el centrado del nombre del archivo en el modal de información del compartido
- Agregado textAlign: 'center' y width: '100%' al componente Text para asegurar centrado correcto

## Test plan
- [x] Verificar que el build de frontend compile sin errores
- [ ] Probar que el nombre del archivo se muestre centrado en el modal
- [ ] Verificar que no hay regresiones en otros modales

## Prioridad
🚨 HOTFIX - Corrección crítica de UI que afecta experiencia del usuario

🤖 Generated with [Claude Code](https://claude.ai/code)